### PR TITLE
[3.x] publishable migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Laravel Package helper for Laravel Packages.
 ```php
 public function boot()
 {
-    $this->publishMigrations(__DIR__.'/../migrations');
+    $this->withPublishableMigrations(__DIR__.'/../migrations');
     
     $this->withSchedule(fn($schedule) => $schedule->command('inspire')->hourly());
 }
@@ -103,6 +103,7 @@ class Cars implements Scope
     }
 }
 ```
+
 > [!TIP]
 > 
 > If you need the model being queried, you can always use `getModel()` over the Eloquent Builder instance. 
@@ -114,7 +115,6 @@ This meta package includes the `WithEnvironmentFile` helper trait to modify the 
 ```php
 use Illuminate\Console\Command;
 use Laragear\Meta\Console\Commands\WithEnvironmentFile;
-
 
 class AddServiceKey extends Command
 {
@@ -143,7 +143,18 @@ composer require --dev laragear/meta-testing
 
 This trait has been eliminated.
 
-This `publishesMigration` method has a signature collision on Laravel 11.x. If you plan to import it to a multi-version Laravel package, consider using your own publishing logic.
+~~This `publishesMigrations` method has a signature collision on Laravel 11.x. If you plan to import it to a multi-version Laravel package, consider using your own publishing logic.~~
+
+You should use the `withPublishableMigrations()` methods with the directories where your migrations are. This method uses `publishesMigrations()` if available, and fallbacks to publishing each single migration file in the path.
+
+```php
+public function boot()
+{
+    // ...
+    
+    $this->withPublishableMigrations(__DIR__.'/../stubs/migrations');
+}
+```
 
 ## Laravel Octane compatibility
 

--- a/src/BootHelpers.php
+++ b/src/BootHelpers.php
@@ -9,10 +9,17 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Laragear\Meta\Http\Middleware\MiddlewareDeclaration;
-
+use SplFileInfo;
+use function array_fill;
+use function array_fill_keys;
+use function count;
 use function is_callable;
 use function is_string;
+use function method_exists;
+use function now;
 
 trait BootHelpers
 {
@@ -143,5 +150,47 @@ trait BootHelpers
         if ($this->app->runningInConsole()) {
             $this->callAfterResolving(Schedule::class, static fn (Schedule $schedule): mixed => $callback($schedule));
         }
+    }
+
+
+    /**
+     * Publish migrations into the application database migrations path.
+     *
+     * @param  string[]|string  $directories
+     * @param  string[]|string  $groups
+     */
+    protected function withPublishableMigrations(array|string $directories, array|string $groups = 'migrations'): void
+    {
+        if (!$this->app->runningInConsole()) {
+            return;
+        }
+
+        $directories = (array) $directories;
+
+        if (method_exists($this, 'publishesMigrations')) {
+            $this->publishesMigrations(array_fill_keys(
+                $directories, array_fill(0, count($directories), $this->app->databasePath('migrations'))
+            ), $groups);
+
+            return;
+        }
+
+        $now = now()->toMutable();
+
+        $files = Collection::make($directories)
+            ->flatMap(function (string $path): array {
+                return $this->app->make('files')->files($path);
+            })
+            ->mapWithKeys(function (SplFileInfo $file) use ($now): array {
+                return [
+                    $file->getRealPath() => $this->app->databasePath(
+                        'migrations/'.
+                        $now->addSecond()->format('Y_m_d_His').
+                        Str::match('/(?<=\d{4}_\d{2}_\d{2}_\d{6}).*/', $file->getFilename())
+                    )
+                ];
+            });
+
+        $this->publishes($files->toArray(), 'migrations');
     }
 }

--- a/src/BootHelpers.php
+++ b/src/BootHelpers.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laragear\Meta\Http\Middleware\MiddlewareDeclaration;
 use SplFileInfo;
+
 use function array_fill;
 use function array_fill_keys;
 use function count;
@@ -152,7 +153,6 @@ trait BootHelpers
         }
     }
 
-
     /**
      * Publish migrations into the application database migrations path.
      *
@@ -161,7 +161,7 @@ trait BootHelpers
      */
     protected function withPublishableMigrations(array|string $directories, array|string $groups = 'migrations'): void
     {
-        if (!$this->app->runningInConsole()) {
+        if (! $this->app->runningInConsole()) {
             return;
         }
 
@@ -187,7 +187,7 @@ trait BootHelpers
                         'migrations/'.
                         $now->addSecond()->format('Y_m_d_His').
                         Str::match('/(?<=\d{4}_\d{2}_\d{2}_\d{6}).*/', $file->getFilename())
-                    )
+                    ),
                 ];
             });
 

--- a/tests/BootHelperTest.php
+++ b/tests/BootHelperTest.php
@@ -146,11 +146,14 @@ class BootHelperTest extends TestCase
         static::assertStringContainsString('inspire', $schedule->events()[0]->command);
     }
 
-    public static function stopTime(): void
+    protected function stopTime(): void
     {
         Carbon::setTestNow(Carbon::create(2012));
     }
 
+    /**
+     * @define-env stopTime
+     */
     #[DefineEnvironment('stopTime')]
     public function test_with_publishable_migrations(): void
     {

--- a/tests/BootHelperTest.php
+++ b/tests/BootHelperTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\ServiceProvider;
 use Laragear\Meta\BootHelpers;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\Http\Kernel;
+
 use function method_exists;
 use function realpath;
 
@@ -159,11 +160,9 @@ class BootHelperTest extends TestCase
             static::assertSame([$this->app->databasePath('migrations')], $files[__DIR__.'/../stubs/migrations']);
         } else {
             static::assertSame([
-                realpath(__DIR__.'/../stubs/migrations/0000_00_00_000000_create_table_foo.php') =>
-                    $this->app->databasePath('migrations/2012_01_01_000001_create_table_foo.php')
+                realpath(__DIR__.'/../stubs/migrations/0000_00_00_000000_create_table_foo.php') => $this->app->databasePath('migrations/2012_01_01_000001_create_table_foo.php'),
             ], $files);
         }
-
     }
 }
 

--- a/tests/BootHelperTest.php
+++ b/tests/BootHelperTest.php
@@ -6,10 +6,14 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Manager;
 use Illuminate\Support\ServiceProvider;
 use Laragear\Meta\BootHelpers;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\Http\Kernel;
+use function method_exists;
+use function realpath;
 
 class BootHelperTest extends TestCase
 {
@@ -140,6 +144,27 @@ class BootHelperTest extends TestCase
         static::assertCount(1, $schedule->events());
         static::assertStringContainsString('inspire', $schedule->events()[0]->command);
     }
+
+    public static function stopTime(): void
+    {
+        Carbon::setTestNow(Carbon::create(2012));
+    }
+
+    #[DefineEnvironment('stopTime')]
+    public function test_with_publishable_migrations(): void
+    {
+        $files = ServiceProvider::$publishes[TestServiceProvider::class];
+
+        if (method_exists(ServiceProvider::class, 'publishesMigrations')) {
+            static::assertSame([$this->app->databasePath('migrations')], $files[__DIR__.'/../stubs/migrations']);
+        } else {
+            static::assertSame([
+                realpath(__DIR__.'/../stubs/migrations/0000_00_00_000000_create_table_foo.php') =>
+                    $this->app->databasePath('migrations/2012_01_01_000001_create_table_foo.php')
+            ], $files);
+        }
+
+    }
 }
 
 class TestServiceProvider extends ServiceProvider
@@ -193,6 +218,8 @@ class TestServiceProvider extends ServiceProvider
         $this->withSchedule(function (Schedule $schedule): void {
             $schedule->command('inspire')->everyFifteenMinutes();
         });
+
+        $this->withPublishableMigrations(__DIR__.'/../stubs/migrations');
     }
 }
 


### PR DESCRIPTION
Laravel 11 comes with `publishMigrations` that publishes migration paths and updates the timestamp of the tables on the go.

Prior Laravel version don't have this method, publishing is done manually per-file.

The new method `withPublishableMigrations` uses `publishMigrations` if available, and falls backs to migrating each file manually.