### PR TITLE
fix php 8.4 Deprecated warnings

### DIFF
--- a/src/BootHelpers.php
+++ b/src/BootHelpers.php
@@ -32,7 +32,7 @@ trait BootHelpers
      * @param  callable|string|null  $callback
      * @return void
      */
-    protected function withDriver(string $service, string|array $driver, callable|string $callback = null): void
+    protected function withDriver(string $service, string|array $driver, callable|string|null $callback = null): void
     {
         if (is_string($driver)) {
             $driver = [$driver => $callback];
@@ -57,7 +57,7 @@ trait BootHelpers
     protected function withValidationRule(
         string $rule,
         callable|string $callback,
-        callable|string $message = null,
+        callable|string|null $message = null,
         bool $implicit = false
     ): void {
         $this->callAfterResolving(

--- a/src/Http/Middleware/MiddlewareDeclaration.php
+++ b/src/Http/Middleware/MiddlewareDeclaration.php
@@ -89,7 +89,7 @@ class MiddlewareDeclaration
      * @param  (callable(\Illuminate\Contracts\Foundation\Application):TValue)|null  $callback
      * @return $this
      */
-    public function shared(callable $callback = null): static
+    public function shared(?callable $callback = null): static
     {
         $this->kernel->getApplication()->singleton($this->middleware, $callback);
 


### PR DESCRIPTION
This fixes php8.4 deprecation warnings:

```
PHP Deprecated:  Laragear\Meta\BootHelpers::withDriver(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in ./src/BootHelpers.php on line 35
```
```
PHP Deprecated:  Laragear\Meta\BootHelpers::withValidationRule(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in ./src/BootHelpers.php on line 57
```
```
Deprecated: Laragear\Meta\Http\Middleware\MiddlewareDeclaration::shared(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in ./src/Http/Middleware/MiddlewareDeclaration.php on line 92
```